### PR TITLE
Improve terminal PTY output handling

### DIFF
--- a/main.js
+++ b/main.js
@@ -262,17 +262,14 @@ class SimpleShell {
     }
     
     childProcess.stdout.on('data', (data) => {
-      // Process the output to handle line endings properly
-      let output = data.toString();
-      // Convert \n to \r\n for proper terminal display
-      output = output.replace(/\n/g, '\r\n');
-      this.sendOutput(output);
+      // Forward data directly to the terminal without modification to
+      // preserve real TTY behaviour. Converting line endings was causing
+      // display issues with interactive applications like Claude Code.
+      this.sendOutput(data.toString());
     });
-    
+
     childProcess.stderr.on('data', (data) => {
-      let output = data.toString();
-      output = output.replace(/\n/g, '\r\n');
-      this.sendOutput(output);
+      this.sendOutput(data.toString());
     });
     
     childProcess.on('exit', (code) => {


### PR DESCRIPTION
## Summary
- keep stdout/stderr output unmodified to better emulate a real TTY

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851ef3e729883249d0313dddbaa3efd